### PR TITLE
Add pytest for lag estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Mask Sense Pilot
+
+This repository contains scripts for analyzing respirator mask leak data.
+
+## Running Tests
+
+Install the required dependencies from `requirements.txt` and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/tests/test_mask_leak_analysis.py
+++ b/tests/test_mask_leak_analysis.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pandas as pd
+
+from mask_leak_analysis import estimate_lag_seconds
+
+
+def test_estimate_lag_seconds_synthetic():
+    fs = 50.0
+    duration = 20.0
+    t = np.arange(0, duration, 1/fs)
+    pressure = np.sin(2 * np.pi * 0.5 * t)
+    dp = np.abs(np.gradient(pressure))
+    lag_seconds = 0.4
+    shift = int(round(lag_seconds * fs))
+    particles = np.concatenate([np.zeros(shift), dp[:-shift]])
+    df = pd.DataFrame({'pressure': pressure, 'particles': particles})
+    est = estimate_lag_seconds(df, fs, 'pressure', 'particles', max_lag_s=1.0)
+    assert abs(est - lag_seconds) <= 1.0 / fs


### PR DESCRIPTION
## Summary
- add README with testing instructions
- write a regression test for `estimate_lag_seconds`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_683b8720776883338e21ced9da0c8be5